### PR TITLE
bug fixes for the 0th second or minute, and the 59th second or minute

### DIFF
--- a/lib/schedulability/parser.rb
+++ b/lib/schedulability/parser.rb
@@ -187,7 +187,7 @@ module Schedulability::Parser
 
 	### Return an Array of Integer minute Ranges for the specified +ranges+ expression.
 	def extract_minute_ranges( ranges )
-		return self.extract_ranges( :minute, ranges, 0, 59 ) do |val|
+		return self.extract_ranges( :minute, ranges, 0, 60 ) do |val|
 			Integer( strip_leading_zeros(val) )
 		end
 	end
@@ -195,7 +195,7 @@ module Schedulability::Parser
 
 	### Return an Array of Integer second Ranges for the specified +ranges+ expression.
 	def extract_second_ranges( ranges )
-		return self.extract_ranges( :second, ranges, 0, 59 ) do |val|
+		return self.extract_ranges( :second, ranges, 0, 60 ) do |val|
 			Integer( strip_leading_zeros(val) )
 		end
 	end
@@ -302,8 +302,10 @@ module Schedulability::Parser
 
 
 	### Return a copy of the specified +val+ with any leading zeros stripped.
+	### If the resulting string is empty, return "0".
 	def strip_leading_zeros( val )
-		return val.sub( /\A0+/, '' )
+		without_leading_zeros = val.sub( /\A0+/, '' )
+		without_leading_zeros.empty? ? '0' : without_leading_zeros
 	end
 
 end # module Schedulability::Parser

--- a/spec/schedulability/schedule_spec.rb
+++ b/spec/schedulability/schedule_spec.rb
@@ -709,6 +709,32 @@ describe Schedulability::Schedule do
 		end
 
 
+		it "doesn't raise a parse error for second values equal to 59" do
+			expect {
+				described_class.parse( 'sec {1 5 10 59}' )
+			}.not_to raise_error
+			expect {
+				described_class.parse( 'sec {59}' )
+			}.not_to raise_error
+			expect {
+				described_class.parse( 'sec {0-59}' )
+			}.not_to raise_error
+		end
+
+
+		it "allows second values equal to 0" do
+			expect {
+				described_class.parse( 'sec {0 5 10 59}' )
+			}.not_to raise_error
+			expect {
+				described_class.parse( 'sec {0}' )
+			}.not_to raise_error
+			expect {
+				described_class.parse( 'sec {0-59}' )
+			}.not_to raise_error
+		end
+
+
 		it "raises a parse error for minute values greater than 59" do
 			expect {
 				described_class.parse( 'min {09 28 68}' )
@@ -716,6 +742,32 @@ describe Schedulability::Schedule do
 			expect {
 				described_class.parse( 'min {60}' )
 			}.to raise_error( Schedulability::ParseError, /invalid minute value: 60/i )
+		end
+
+
+		it "doesn't raise a parse error for minute values equal to 59" do
+			expect {
+				described_class.parse( 'min {1 5 10 59}' )
+			}.not_to raise_error
+			expect {
+				described_class.parse( 'min {59}' )
+			}.not_to raise_error
+			expect {
+				described_class.parse( 'min {0-59}' )
+			}.not_to raise_error
+		end
+
+
+		it "allows minute values equal to 0" do
+			expect {
+				described_class.parse( 'min {0 5 10 59}' )
+			}.not_to raise_error
+			expect {
+				described_class.parse( 'min {0}' )
+			}.not_to raise_error
+			expect {
+				described_class.parse( 'min {0-59}' )
+			}.not_to raise_error
 		end
 
 


### PR DESCRIPTION
This allows for the specification of `0` and `59` as valid minutes and seconds according to the documentation.

Ex.
```
wd{Mon Thu} yd{168-196} hr{08} min{0-59}, \
wd{Mon Thu} yd{168-196} hr{12} min{0-29}, \
not yd{171} yr{2016}, not yd{193} yr{2016}
```